### PR TITLE
feat: Add public Explore Projects page with dummy data and route

### DIFF
--- a/frontend/src/AppRoutes.jsx
+++ b/frontend/src/AppRoutes.jsx
@@ -6,7 +6,8 @@ import Layout from "./layout/Layout";
 
 // Pages
 import Landing from "./pages/Landing";
-import Explore from "./pages/ExploreProject"; // This is ExploreProjects
+import ExploreProject from "./pages/ExploreProject"; // This is ExploreProjects
+import Explore from "./pages/Explore";
 import Messages from "./pages/Messages";
 import Profile from "./pages/Profile";
 import CreateProfile from "./pages/CreateProfile";
@@ -36,7 +37,7 @@ export default function AppRoutes() {
         path="/explore-projects" // ✅ Updated path
         element={
           <Layout>
-            <Explore />
+            <ExploreProject/>
           </Layout>
         }
       />

--- a/frontend/src/AppRoutes.jsx
+++ b/frontend/src/AppRoutes.jsx
@@ -6,7 +6,7 @@ import Layout from "./layout/Layout";
 
 // Pages
 import Landing from "./pages/Landing";
-import Explore from "./pages/Explore"; // This is ExploreProjects
+import Explore from "./pages/ExploreProject"; // This is ExploreProjects
 import Messages from "./pages/Messages";
 import Profile from "./pages/Profile";
 import CreateProfile from "./pages/CreateProfile";

--- a/frontend/src/AppRoutes.jsx
+++ b/frontend/src/AppRoutes.jsx
@@ -6,8 +6,7 @@ import Layout from "./layout/Layout";
 
 // Pages
 import Landing from "./pages/Landing";
-import Explore from "./pages/Explore";
-// import PostProject from "./pages/PostProject";
+import Explore from "./pages/Explore"; // This is ExploreProjects
 import Messages from "./pages/Messages";
 import Profile from "./pages/Profile";
 import CreateProfile from "./pages/CreateProfile";
@@ -34,14 +33,21 @@ export default function AppRoutes() {
         }
       />
       <Route
-        path="/explore"
+        path="/explore-projects" // ✅ Updated path
         element={
           <Layout>
             <Explore />
           </Layout>
         }
       />
-      {/* <Route path="/post-project" element={<Layout><PostProject /></Layout>} /> */}
+      <Route
+        path="/post-project"
+        element={
+          <Layout>
+            <PostProjectPage />
+          </Layout>
+        }
+      />
       <Route
         path="/messages"
         element={
@@ -63,14 +69,6 @@ export default function AppRoutes() {
         element={
           <Layout>
             <CreateProfile />
-          </Layout>
-        }
-      />
-      <Route
-        path="/post-project"
-        element={
-          <Layout>
-            <PostProjectPage />
           </Layout>
         }
       />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -33,7 +33,15 @@ export default function Navbar() {
             to="/explore-projects"
             className="text-gray-400 hover:text-white transition"
           >
-            Explore
+            Explore Projects 
+          </Link>
+
+          {/* ✅ Updated path */}
+          <Link
+            to="/explore"
+            className="text-gray-400 hover:text-white transition"
+          >
+            Explore 
           </Link>
 
           <Link

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -27,12 +27,15 @@ export default function Navbar() {
           <Link to="/" className="text-gray-400 hover:text-white transition">
             Landing
           </Link>
+
+          {/* ✅ Updated path */}
           <Link
-            to="/explore"
+            to="/explore-projects"
             className="text-gray-400 hover:text-white transition"
           >
             Explore
           </Link>
+
           <Link
             to="/my-projects"
             className="text-gray-400 hover:text-white transition"

--- a/frontend/src/components/PostProjectForm.jsx
+++ b/frontend/src/components/PostProjectForm.jsx
@@ -14,11 +14,15 @@ const PostProjectForm = () => {
     maxTeamSize: "",
     deadline: "",
     tags: "",
+    openForCollab: false, // ✅ NEW
   });
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === "checkbox" ? checked : value,
+    }));
   };
 
   const handleSubmit = (e) => {
@@ -104,6 +108,20 @@ const PostProjectForm = () => {
                 <option>Open to all</option>
                 <option>Invite only</option>
               </select>
+            </div>
+
+            {/* ✅ Open for Collaboration checkbox */}
+            <div className="flex items-center gap-3 mt-4">
+              <input
+                type="checkbox"
+                name="openForCollab"
+                checked={formData.openForCollab}
+                onChange={handleChange}
+                className="w-5 h-5 text-blue-600 bg-gray-900 border-gray-700 rounded focus:ring-blue-500"
+              />
+              <label className="text-sm text-gray-300">
+                Open for Collaboration
+              </label>
             </div>
           </div>
 

--- a/frontend/src/data/dummyProjects.js
+++ b/frontend/src/data/dummyProjects.js
@@ -1,0 +1,18 @@
+export const dummyProjects = [
+    {
+      id: 1,
+      title: "AI-Powered Career Advisor",
+      description: "A chatbot to help students pick a career path.",
+      techStack: ["React", "Node.js", "OpenAI API"],
+      status: "Open for Collaboration",
+      rolesNeeded: ["Frontend Dev", "ML Engineer"],
+    },
+    {
+      id: 2,
+      title: "Collaborative Note Sharing App",
+      description: "An app to let students share class notes in real-time.",
+      techStack: ["Next.js", "Firebase"],
+      status: "Open for Collaboration",
+      rolesNeeded: ["UI/UX Designer", "Backend Dev"],
+    }
+  ];

--- a/frontend/src/pages/Explore.jsx
+++ b/frontend/src/pages/Explore.jsx
@@ -1,56 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { dummyProjects } from "../data/dummyProjects";
-
+import react from "react";  
 const Explore = () => {
-  const [loading, setLoading] = useState(true);
-  const [projects, setProjects] = useState([]);
-
-  useEffect(() => {
-    setTimeout(() => {
-      setProjects(dummyProjects);
-      setLoading(false);
-    }, 1000); // simulate loading
-  }, []);
-
-  if (loading) {
-    return <p className="text-center text-white mt-10">Loading projects...</p>;
-  }
-
-  if (projects.length === 0) {
-    return <p className="text-center text-white mt-10">No open projects available.</p>;
-  }
-
-  return (
-    <div className="max-w-5xl mx-auto px-4 py-10 text-white">
-      <h1 className="text-3xl font-bold mb-6">Explore Open Projects</h1>
-      <div className="grid md:grid-cols-2 gap-6">
-        {projects.map((project) => (
-          <div
-            key={project.id}
-            className="bg-gray-900 p-6 rounded-xl border border-gray-700"
-          >
-            <h2 className="text-xl font-semibold">{project.title}</h2>
-            <p className="text-gray-400 mt-2">{project.description}</p>
-            <p className="mt-2 text-sm">
-              <strong>Tech Stack:</strong> {project.techStack.join(", ")}
-            </p>
-            <p className="text-sm">
-              <strong>Status:</strong> {project.status}
-            </p>
-            <p className="text-sm">
-              <strong>Roles Needed:</strong> {project.rolesNeeded.join(", ")}
-            </p>
-            <button
-              onClick={() => console.log(`Interest in: ${project.title}`)}
-              className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-            >
-              Show Interest
-            </button>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-export default Explore;
+    return (
+        <div>Explore</div>
+    )
+}

--- a/frontend/src/pages/Explore.jsx
+++ b/frontend/src/pages/Explore.jsx
@@ -1,4 +1,56 @@
-// src/pages/Explore.jsx
-export default function Explore() {
-  return <div className="text-white text-center mt-10">Explore Page</div>;
-}
+import React, { useState, useEffect } from "react";
+import { dummyProjects } from "../data/dummyProjects";
+
+const Explore = () => {
+  const [loading, setLoading] = useState(true);
+  const [projects, setProjects] = useState([]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setProjects(dummyProjects);
+      setLoading(false);
+    }, 1000); // simulate loading
+  }, []);
+
+  if (loading) {
+    return <p className="text-center text-white mt-10">Loading projects...</p>;
+  }
+
+  if (projects.length === 0) {
+    return <p className="text-center text-white mt-10">No open projects available.</p>;
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold mb-6">Explore Open Projects</h1>
+      <div className="grid md:grid-cols-2 gap-6">
+        {projects.map((project) => (
+          <div
+            key={project.id}
+            className="bg-gray-900 p-6 rounded-xl border border-gray-700"
+          >
+            <h2 className="text-xl font-semibold">{project.title}</h2>
+            <p className="text-gray-400 mt-2">{project.description}</p>
+            <p className="mt-2 text-sm">
+              <strong>Tech Stack:</strong> {project.techStack.join(", ")}
+            </p>
+            <p className="text-sm">
+              <strong>Status:</strong> {project.status}
+            </p>
+            <p className="text-sm">
+              <strong>Roles Needed:</strong> {project.rolesNeeded.join(", ")}
+            </p>
+            <button
+              onClick={() => console.log(`Interest in: ${project.title}`)}
+              className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            >
+              Show Interest
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Explore;

--- a/frontend/src/pages/ExploreProject.jsx
+++ b/frontend/src/pages/ExploreProject.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { dummyProjects } from "../data/dummyProjects";
 
-const Explore = () => {
+const ExploreProject = () => {
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState([]);
 
@@ -53,4 +53,4 @@ const Explore = () => {
   );
 };
 
-export default Explore;
+export default ExploreProject;

--- a/frontend/src/pages/ExploreProject.jsx
+++ b/frontend/src/pages/ExploreProject.jsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from "react";
+import { dummyProjects } from "../data/dummyProjects";
+
+const Explore = () => {
+  const [loading, setLoading] = useState(true);
+  const [projects, setProjects] = useState([]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setProjects(dummyProjects);
+      setLoading(false);
+    }, 1000); // simulate loading
+  }, []);
+
+  if (loading) {
+    return <p className="text-center text-white mt-10">Loading projects...</p>;
+  }
+
+  if (projects.length === 0) {
+    return <p className="text-center text-white mt-10">No open projects available.</p>;
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-10 text-white">
+      <h1 className="text-3xl font-bold mb-6">Explore Open Projects</h1>
+      <div className="grid md:grid-cols-2 gap-6">
+        {projects.map((project) => (
+          <div
+            key={project.id}
+            className="bg-gray-900 p-6 rounded-xl border border-gray-700"
+          >
+            <h2 className="text-xl font-semibold">{project.title}</h2>
+            <p className="text-gray-400 mt-2">{project.description}</p>
+            <p className="mt-2 text-sm">
+              <strong>Tech Stack:</strong> {project.techStack.join(", ")}
+            </p>
+            <p className="text-sm">
+              <strong>Status:</strong> {project.status}
+            </p>
+            <p className="text-sm">
+              <strong>Roles Needed:</strong> {project.rolesNeeded.join(", ")}
+            </p>
+            <button
+              onClick={() => console.log(`Interest in: ${project.title}`)}
+              className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            >
+              Show Interest
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Explore;


### PR DESCRIPTION
- Implemented a new route `/explore-projects` to publicly list project ideas marked as "Open for Collaboration"
- Created ExploreProjects page using local dummy data with loading and empty states
- Each project card displays title, description, tech stack, roles needed, and a "Show Interest" button
- Updated Navbar to link to the new /explore-projects route
- Added checkbox to Post Project form to mark a project as open for collaboration
- Console logs the submitted data and interest clicks for simulation (no backend yet)