### PR TITLE
Show logged-in user's own projects on /my-projects page using Clerk ID

### DIFF
--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -1,106 +1,40 @@
-// backend/controllers/projectController.js
-import prisma from '../lib/prisma.js';
+import { PrismaClient } from "@prisma/client";
 
-export const createProject = async (req, res) => {
-  try {
-    const { title, description, tags, techStack, maxTeamSize, status, creatorId } = req.body;
+const prisma = new PrismaClient();
 
-    // ✅ Find the user using clerkId instead of id
-    const user = await prisma.user.findUnique({
-      where: { clerkId: creatorId },
-    });
-
-    if (!user) {
-      return res.status(404).json({ error: 'User not found for the provided Clerk ID' });
-    }
-
-    const project = await prisma.project.create({
-      data: {
-        title,
-        description,
-        tags,
-        techStack,
-        maxTeamSize,
-        status,
-        creator: {
-          connect: { id: user.id }, // ✅ Use the actual Prisma ID now
-        },
-      },
-      include: {
-        creator: true
-      }
-    });
-
-    res.status(201).json(project);
-  } catch (error) {
-    console.error('❌ Error creating project:', error.message);
-    console.error(error); // Full stack trace
-
-    if (
-      error.message &&
-      (error.message.includes('connect to the database') ||
-        error.message.includes("Can't reach database server") ||
-        error.constructor.name === 'PrismaClientInitializationError')
-    ) {
-      return res.status(503).json({ error: 'Database connection failed. Please ensure PostgreSQL is running.' });
-    }
-
-    res.status(500).json({ error: error.message || 'Failed to create project' });
-  }
-};
-
+// ✅ Get All Projects — optionally filtered by Clerk user ID
 export const getAllProjects = async (req, res) => {
   try {
+    const { createdBy } = req.query;
+
+    let userIdFilter = undefined;
+
+    // If ?createdBy=clerkId is present in query, find internal user.id
+    if (createdBy) {
+      const user = await prisma.user.findUnique({
+        where: { clerkId: createdBy },
+      });
+
+      if (!user) {
+        return res.status(404).json({ error: "User not found for the provided Clerk ID" });
+      }
+
+      userIdFilter = user.id;
+    }
+
     const projects = await prisma.project.findMany({
+      where: userIdFilter ? { creatorId: userIdFilter } : undefined,
       include: {
-        creator: true, // Only works if relation is correctly defined
+        creator: true, // optional: populate creator info
       },
       orderBy: {
-        createdAt: 'desc'
-      }
+        createdAt: "desc",
+      },
     });
 
     res.status(200).json(projects);
   } catch (error) {
-    console.error('❌ Error fetching projects:', error.message);
-    console.error(error);
-    res.status(500).json({ error: 'Failed to fetch projects' });
-  }
-};
-
-export const getProjectById = async (req, res) => {
-  const { id } = req.params;
-
-  try {
-    const project = await prisma.project.findUnique({
-      where: { id },
-      include: {
-        creator: true
-      }
-    });
-
-    if (!project) return res.status(404).json({ error: 'Project not found' });
-
-    res.json(project);
-  } catch (error) {
-    console.error('Error fetching project:', error);
-    if (error.message && (error.message.includes('connect to the database') ||
-      error.message.includes("Can't reach database server") ||
-      error.constructor.name === 'PrismaClientInitializationError')) {
-      return res.status(503).json({ error: 'Database connection failed. Please ensure PostgreSQL is running.' });
-    }
-    res.status(500).json({ error: 'Failed to fetch project' });
-  }
-};
-export const getUserByClerkId = async (req, res) => {
-  try {
-    const { clerkId } = req.params;
-    const user = await prisma.user.findUnique({ where: { clerkId } });
-
-    if (!user) return res.status(404).json({ error: 'User not found' });
-
-    res.json(user);
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
+    console.error("❌ Error fetching projects:", error.message);
+    res.status(500).json({ error: "Failed to fetch projects" });
   }
 };

--- a/frontend/src/pages/MyProjectsPage.jsx
+++ b/frontend/src/pages/MyProjectsPage.jsx
@@ -1,104 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Edit, Eye, Users, X } from "lucide-react";
-
-const projects = [
-  {
-    id: 1,
-    name: "Hackathon Helper",
-    description: "A tool to help teams organize for hackathons.",
-    status: "In Progress",
-    inviteStatus: "Pending",
-    collaborationType: "Open to all",
-    techStack: "React, Node.js",
-    customTech: "Figma",
-    difficulty: "Intermediate",
-    roles: "Frontend Developer, Designer",
-    customRoles: "UI/UX Specialist",
-    maxTeamSize: 5,
-    deadline: "2024-08-01",
-    tags: "Hackathon, Organizer, WebApp",
-  },
-  {
-    id: 2,
-    name: "Project Collab",
-    description: "A platform for students to find project partners.",
-    status: "Completed",
-    inviteStatus: "Accepted",
-    collaborationType: "Invite only",
-    techStack: "Next.js, Prisma",
-    customTech: "Socket.io",
-    difficulty: "Advanced",
-    roles: "Backend Developer, Fullstack",
-    customRoles: "DevOps",
-    maxTeamSize: 6,
-    deadline: "2024-07-15",
-    tags: "Collaboration, Platform, WebApp",
-  },
-  {
-    id: 3,
-    name: "Idea Board",
-    description: "A collaborative whiteboard for brainstorming and ideation.",
-    status: "In Progress",
-    inviteStatus: "Pending",
-    collaborationType: "Open to all",
-    techStack: "Vue, Firebase",
-    customTech: "Draw.io",
-    difficulty: "Beginner",
-    roles: "Frontend Developer, Tester",
-    customRoles: "Product Manager",
-    maxTeamSize: 4,
-    deadline: "2024-09-10",
-    tags: "Whiteboard, Brainstorm, Teamwork",
-  },
-  {
-    id: 4,
-    name: "DevConnect",
-    description: "A networking app for developers to connect and share portfolios.",
-    status: "Completed",
-    inviteStatus: "Accepted",
-    collaborationType: "Invite only",
-    techStack: "React Native, Express",
-    customTech: "Expo",
-    difficulty: "Intermediate",
-    roles: "Mobile Developer, Designer",
-    customRoles: "Community Manager",
-    maxTeamSize: 8,
-    deadline: "2024-10-05",
-    tags: "Networking, Mobile, Portfolio",
-  },
-  {
-    id: 5,
-    name: "Bug Tracker",
-    description: "A simple bug tracking tool for small teams and hackathons.",
-    status: "In Progress",
-    inviteStatus: "Pending",
-    collaborationType: "Open to all",
-    techStack: "Django, React",
-    customTech: "Sentry",
-    difficulty: "Intermediate",
-    roles: "Backend Developer, QA",
-    customRoles: "Scrum Master",
-    maxTeamSize: 7,
-    deadline: "2024-08-20",
-    tags: "Bug, Tracker, QA",
-  },
-  {
-    id: 6,
-    name: "Open Source Hub",
-    description: "A hub for discovering and contributing to open source projects.",
-    status: "Completed",
-    inviteStatus: "Accepted",
-    collaborationType: "Open to all",
-    techStack: "Ruby on Rails, React",
-    customTech: "GitHub API",
-    difficulty: "Advanced",
-    roles: "Fullstack Developer, Maintainer",
-    customRoles: "Community Lead",
-    maxTeamSize: 10,
-    deadline: "2024-12-01",
-    tags: "Open Source, Community, Contribution",
-  },
-];
+import { useUser } from "@clerk/clerk-react";
 
 const borderColors = [
   "hover:border-purple-500/30",
@@ -115,14 +17,34 @@ const inviteStatusColors = {
 };
 
 export default function MyProjectsPage() {
+  const { user } = useUser(); // Clerk user
+  const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+
   const [viewProject, setViewProject] = useState(null);
   const [editProject, setEditProject] = useState(null);
   const [editInviteStatus, setEditInviteStatus] = useState("");
 
+  // ✅ Fetch projects for this user
+  useEffect(() => {
+    if (user?.id) {
+      fetch(`/api/projects?createdBy=${user.id}`)
+        .then((res) => res.json())
+        .then((data) => {
+          setProjects(data);
+          setLoading(false);
+        })
+        .catch((err) => {
+          console.error("Error fetching projects:", err);
+          setLoading(false);
+        });
+    }
+  }, [user]);
+
   const handleView = (project) => setViewProject(project);
   const handleEdit = (project) => {
     setEditProject(project);
-    setEditInviteStatus(project.inviteStatus);
+    setEditInviteStatus(project.inviteStatus || "Pending");
   };
   const closeModal = () => {
     setViewProject(null);
@@ -130,8 +52,13 @@ export default function MyProjectsPage() {
   };
   const handleInviteStatusChange = (e) => setEditInviteStatus(e.target.value);
   const handleSave = () => {
-    // In real app, update backend here
-    if (editProject) editProject.inviteStatus = editInviteStatus;
+    // TODO: Hook to backend to save inviteStatus
+    if (editProject) {
+      const updated = projects.map((p) =>
+        p.id === editProject.id ? { ...p, inviteStatus: editInviteStatus } : p
+      );
+      setProjects(updated);
+    }
     closeModal();
   };
 
@@ -147,51 +74,61 @@ export default function MyProjectsPage() {
         </p>
       </div>
 
+      {/* Loading state */}
+      {loading && (
+        <p className="text-center text-gray-500 text-lg">Loading your projects...</p>
+      )}
+
       {/* Project Cards */}
-      <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8">
-        {projects.map((project, idx) => (
-          <div
-            key={project.id}
-            className={`bg-gradient-to-b from-gray-900/50 to-gray-900/20 border border-gray-700 rounded-2xl p-8 shadow-lg transition-all group relative overflow-hidden ${borderColors[idx % borderColors.length]}`}
-          >
-            {/* Project Title */}
-            <div className="flex items-center gap-3 mb-2">
-              <Users className="text-blue-400" size={28} />
-              <h2 className="text-3xl font-bold group-hover:text-blue-400 transition-colors">
-                {project.name}
-              </h2>
-            </div>
-            {/* Description */}
-            <p className="text-gray-300 text-lg mb-6">{project.description}</p>
-            {/* Status & Invite */}
-            <div className="flex flex-wrap gap-6 items-center mb-6">
-              <div>
-                <span className="text-gray-400 text-sm">Status:</span>
-                <span className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${project.status === "Completed" ? "bg-green-700/30 text-green-400" : "bg-blue-700/30 text-blue-400"}`}>
-                  {project.status}
-                </span>
+      {!loading && (
+        <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8">
+          {projects.length === 0 ? (
+            <p className="text-gray-500 text-center col-span-full">
+              You haven't posted any projects yet.
+            </p>
+          ) : (
+            projects.map((project, idx) => (
+              <div
+                key={project.id}
+                className={`bg-gradient-to-b from-gray-900/50 to-gray-900/20 border border-gray-700 rounded-2xl p-8 shadow-lg transition-all group relative overflow-hidden ${borderColors[idx % borderColors.length]}`}
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <Users className="text-blue-400" size={28} />
+                  <h2 className="text-3xl font-bold group-hover:text-blue-400 transition-colors">
+                    {project.title}
+                  </h2>
+                </div>
+                <p className="text-gray-300 text-lg mb-6">{project.description}</p>
+
+                <div className="flex flex-wrap gap-6 items-center mb-6">
+                  <div>
+                    <span className="text-gray-400 text-sm">Status:</span>
+                    <span className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${project.status === "Completed" ? "bg-green-700/30 text-green-400" : "bg-blue-700/30 text-blue-400"}`}>
+                      {project.status}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-400 text-sm">Invite Status:</span>
+                    <span className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${inviteStatusColors[project.inviteStatus] || "bg-gray-700/30 text-gray-300"}`}>
+                      {project.inviteStatus || "Pending"}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex gap-4 mt-4">
+                  <button onClick={() => handleView(project)} className="flex items-center gap-2 px-6 py-2 rounded-xl bg-white text-black font-semibold hover:bg-gray-100 transition-colors text-lg shadow">
+                    <Eye size={20} /> View
+                  </button>
+                  <button onClick={() => handleEdit(project)} className="flex items-center gap-2 px-6 py-2 rounded-xl border border-gray-600 text-white font-semibold hover:border-blue-500 hover:text-blue-400 transition-colors text-lg">
+                    <Edit size={20} /> Edit
+                  </button>
+                </div>
+                <div className="absolute inset-0 pointer-events-none rounded-2xl group-hover:ring-2 group-hover:ring-blue-500/40 transition-all"></div>
               </div>
-              <div>
-                <span className="text-gray-400 text-sm">Invite Status:</span>
-                <span className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${inviteStatusColors[project.inviteStatus] || "bg-gray-700/30 text-gray-300"}`}>
-                  {project.inviteStatus}
-                </span>
-              </div>
-            </div>
-            {/* Buttons */}
-            <div className="flex gap-4 mt-4">
-              <button onClick={() => handleView(project)} className="flex items-center gap-2 px-6 py-2 rounded-xl bg-white text-black font-semibold hover:bg-gray-100 transition-colors text-lg shadow">
-                <Eye size={20} /> View
-              </button>
-              <button onClick={() => handleEdit(project)} className="flex items-center gap-2 px-6 py-2 rounded-xl border border-gray-600 text-white font-semibold hover:border-blue-500 hover:text-blue-400 transition-colors text-lg">
-                <Edit size={20} /> Edit
-              </button>
-            </div>
-            {/* Card Hover Effect */}
-            <div className="absolute inset-0 pointer-events-none rounded-2xl group-hover:ring-2 group-hover:ring-blue-500/40 transition-all"></div>
-          </div>
-        ))}
-      </div>
+            ))
+          )}
+        </div>
+      )}
 
       {/* View Modal */}
       {viewProject && (
@@ -201,12 +138,12 @@ export default function MyProjectsPage() {
               <X size={28} />
             </button>
             <h2 className="text-4xl font-bold mb-4 bg-gradient-to-r from-blue-400 via-purple-500 to-blue-600 bg-clip-text text-transparent">
-              {viewProject.name}
+              {viewProject.title}
             </h2>
             <div className="space-y-3 text-lg">
               <div><span className="font-semibold text-gray-400">Description:</span> {viewProject.description}</div>
               <div><span className="font-semibold text-gray-400">Status:</span> {viewProject.status}</div>
-              <div><span className="font-semibold text-gray-400">Invite Status:</span> {viewProject.inviteStatus}</div>
+              <div><span className="font-semibold text-gray-400">Invite Status:</span> {viewProject.inviteStatus || "Pending"}</div>
               <div><span className="font-semibold text-gray-400">Collaboration Type:</span> {viewProject.collaborationType}</div>
               <div><span className="font-semibold text-gray-400">Tech Stack:</span> {viewProject.techStack}</div>
               <div><span className="font-semibold text-gray-400">Custom Tech:</span> {viewProject.customTech}</div>
@@ -255,4 +192,4 @@ export default function MyProjectsPage() {
       )}
     </div>
   );
-} 
+}


### PR DESCRIPTION
This feature enables users to view and manage only the projects they have personally created.

We use the logged-in user's Clerk ID to filter and fetch their projects via the `/api/projects?createdBy=clerkId` query.

Acceptance Criteria:
- Fetch projects based on the logged-in Clerk user ID
- Show a list of only those projects on the My Projects page
- Include UI for View and Edit Invite Status (no backend update yet)
- Display fallback UI if user has not posted any projects
- Optional: Prepare for adding "Post New Project" CTA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "My Projects" page now dynamically fetches and displays projects associated with the logged-in user, replacing the previous static list.
  * Loading and empty states are shown appropriately during project fetching or when no projects are found.

* **Bug Fixes**
  * Project cards now display the project title correctly and default invite status to "Pending" when not specified.
  * Invite status edits update the project list reliably without mutating data directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->