### PR TITLE
feat: implement full project posting flow with filtering and interest…

### DIFF
--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -1,17 +1,28 @@
-// backend/controllers/projectController.js
-import prisma from '../lib/prisma.js';
+import prisma from "../lib/prisma.js";
 
+// Create Project
 export const createProject = async (req, res) => {
   try {
-    const { title, description, tags, techStack, maxTeamSize, status, creatorId } = req.body;
+    const {
+      title,
+      description,
+      tags,
+      techStack,
+      maxTeamSize,
+      status,
+      difficulty,
+      visibility,
+      creatorId,
+    } = req.body;
 
-    // ✅ Find the user using clerkId instead of id
     const user = await prisma.user.findUnique({
       where: { clerkId: creatorId },
     });
 
     if (!user) {
-      return res.status(404).json({ error: 'User not found for the provided Clerk ID' });
+      return res
+        .status(404)
+        .json({ error: "User not found for the provided Clerk ID" });
     }
 
     const project = await prisma.project.create({
@@ -22,85 +33,148 @@ export const createProject = async (req, res) => {
         techStack,
         maxTeamSize,
         status,
-        creator: {
-          connect: { id: user.id }, // ✅ Use the actual Prisma ID now
-        },
+        difficulty,
+        visibility,
+        inviteStatus: "Pending",
+        creator: { connect: { id: user.id } },
       },
-      include: {
-        creator: true
-      }
+      include: { creator: true },
     });
 
     res.status(201).json(project);
   } catch (error) {
-    console.error('❌ Error creating project:', error.message);
-    console.error(error); // Full stack trace
-
-    if (
-      error.message &&
-      (error.message.includes('connect to the database') ||
-        error.message.includes("Can't reach database server") ||
-        error.constructor.name === 'PrismaClientInitializationError')
-    ) {
-      return res.status(503).json({ error: 'Database connection failed. Please ensure PostgreSQL is running.' });
+    console.error("❌ Error creating project:", error.message);
+    if (error.message?.includes("connect to the database")) {
+      return res.status(503).json({
+        error:
+          "Database connection failed. Please ensure PostgreSQL is running.",
+      });
     }
-
-    res.status(500).json({ error: error.message || 'Failed to create project' });
+    res
+      .status(500)
+      .json({ error: error.message || "Failed to create project" });
   }
 };
 
+// Get all public projects (Explore)
 export const getAllProjects = async (req, res) => {
   try {
+    const { tech, tags, difficulty } = req.query;
+
+    const filters = {
+      visibility: "Open to All",
+      ...(tech && { techStack: { hasSome: tech.split(",") } }),
+      ...(tags && { tags: { hasSome: tags.split(",") } }),
+      ...(difficulty && { difficulty }),
+    };
+
     const projects = await prisma.project.findMany({
-      include: {
-        creator: true, // Only works if relation is correctly defined
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
+      where: filters,
+      include: { creator: true },
+      orderBy: { createdAt: "desc" },
     });
 
     res.status(200).json(projects);
   } catch (error) {
-    console.error('❌ Error fetching projects:', error.message);
-    console.error(error);
-    res.status(500).json({ error: 'Failed to fetch projects' });
+    console.error("❌ Error fetching projects:", error.message);
+    res.status(500).json({ error: "Failed to fetch projects" });
   }
 };
 
+// Get project by ID
 export const getProjectById = async (req, res) => {
   const { id } = req.params;
-
   try {
     const project = await prisma.project.findUnique({
       where: { id },
       include: {
-        creator: true
-      }
+        creator: true,
+        interestedUsers: true,
+      },
     });
 
-    if (!project) return res.status(404).json({ error: 'Project not found' });
+    if (!project) return res.status(404).json({ error: "Project not found" });
 
     res.json(project);
   } catch (error) {
-    console.error('Error fetching project:', error);
-    if (error.message && (error.message.includes('connect to the database') ||
-      error.message.includes("Can't reach database server") ||
-      error.constructor.name === 'PrismaClientInitializationError')) {
-      return res.status(503).json({ error: 'Database connection failed. Please ensure PostgreSQL is running.' });
-    }
-    res.status(500).json({ error: 'Failed to fetch project' });
+    console.error("Error fetching project:", error);
+    res.status(500).json({ error: "Failed to fetch project" });
   }
 };
+
+// Show interest in a project
+export const showInterest = async (req, res) => {
+  try {
+    const { projectId } = req.params;
+    const { userId } = req.body;
+
+    const project = await prisma.project.update({
+      where: { id: projectId },
+      data: {
+        interestedUsers: {
+          connect: { id: userId }
+        }
+      }
+    });
+
+    res.status(200).json(project);
+  } catch (error) {
+    console.error("❌ Error showing interest:", error);
+    res.status(500).json({ error: "Failed to show interest in project" });
+  }
+};
+
+// Get projects created by current user
+export const getMyProjects = async (req, res) => {
+  const { clerkId } = req.params;
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { clerkId },
+    });
+
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const projects = await prisma.project.findMany({
+      where: { creatorId: user.id },
+      include: { creator: true },
+    });
+
+    res.json(projects);
+  } catch (error) {
+    console.error("Error fetching my projects:", error);
+    res.status(500).json({ error: "Failed to fetch user projects" });
+  }
+};
+
+// ✅ Update invite status of a project
+export const updateProjectInviteStatus = async (req, res) => {
+  const { id } = req.params;
+  const { inviteStatus } = req.body;
+
+  try {
+    const updated = await prisma.project.update({
+      where: { id },
+      data: { inviteStatus },
+    });
+
+    res.json(updated);
+  } catch (error) {
+    console.error("Error updating invite status:", error);
+    res.status(500).json({ error: "Failed to update invite status" });
+  }
+};
+
+// Optional helper
 export const getUserByClerkId = async (req, res) => {
   try {
     const { clerkId } = req.params;
     const user = await prisma.user.findUnique({ where: { clerkId } });
 
-    if (!user) return res.status(404).json({ error: 'User not found' });
+    if (!user) return res.status(404).json({ error: "User not found" });
 
     res.json(user);
   } catch (err) {
-    res.status(500).json({ error: 'Server error' });
+    res.status(500).json({ error: "Server error" });
   }
 };

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -51,12 +51,10 @@ export const getUsers = async (req, res) => {
         error.message.includes("Can't reach database server") ||
         error.constructor.name === "PrismaClientInitializationError")
     ) {
-      return res
-        .status(503)
-        .json({
-          error:
-            "Database connection failed. Please ensure PostgreSQL is running.",
-        });
+      return res.status(503).json({
+        error:
+          "Database connection failed. Please ensure PostgreSQL is running.",
+      });
     }
     res.status(500).json({ error: "Failed to fetch users" });
   }
@@ -66,7 +64,16 @@ export const getUsers = async (req, res) => {
 export const getUserByClerkId = async (req, res) => {
   try {
     const { clerkId } = req.params;
-    const user = await prisma.user.findUnique({ where: { clerkId } });
+    const user = await prisma.user.findUnique({
+      where: { clerkId },
+      include: {
+        skills: {
+          include: { skill: true },
+        },
+        // You can include projects here if needed, e.g.:
+        // projects: true,
+      },
+    });
 
     if (!user) return res.status(404).json({ error: "User not found" });
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,7 +23,7 @@ model User {
   updatedAt    DateTime @updatedAt
 
   skills   UserSkill[]
-  projects Project[] // 👈 Add this
+  projects Project[] // 👈 One-to-many relationship with projects
 }
 
 model Skill {
@@ -46,16 +46,22 @@ model UserSkill {
 }
 
 model Project {
-  id          String   @id @default(uuid())
-  title       String
-  description String
-  tags        String[] // ✅ Array field
-  techStack   String[] // ✅ Array field
-  maxTeamSize Int
-  status      String   @default("Open")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                String   @id @default(uuid())
+  title             String
+  description       String
+  tags              String[] // ✅ Array field
+  techStack         String[] // ✅ Array field
+  maxTeamSize       Int
+  status            String   @default("Open")
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
+  collaborationType String           // ✅ New
+  difficulty        String           // ✅ New
+  rolesNeeded       String[]         // ✅ New
+  deadline          DateTime?        // ✅ New
+  visibility      String    @default("Open to All")
+  interestedUsers User[]    @relation("ProjectInterest")
   creator   User   @relation(fields: [creatorId], references: [id])
   creatorId String
 }

--- a/backend/routes/projectRoutes.js
+++ b/backend/routes/projectRoutes.js
@@ -1,17 +1,20 @@
-// projectRoutes.js
-
-import express from 'express';
+import express from "express";
 import {
   createProject,
   getAllProjects,
   getProjectById,
-} from '../controllers/projectController.js';
+  showInterest,
+  getMyProjects,
+  updateProjectInviteStatus, // ✅
+} from "../controllers/projectController.js";
 
 const router = express.Router();
 
-router.post('/', createProject);
-router.get('/', getAllProjects);
-router.get('/:id', getProjectById);
+router.post("/", createProject); // Create new project
+router.get("/", getAllProjects); // Explore page
+router.get("/:id", getProjectById); // Single project
+router.post('/:projectId/interest', showInterest);
+router.get("/my-projects/:clerkId", getMyProjects); // My projects
+router.patch("/:id", updateProjectInviteStatus); // ✅ Update invite status
 
-//  Use ESM export, not CommonJS
 export default router;

--- a/frontend/src/components/PostProjectForm.jsx
+++ b/frontend/src/components/PostProjectForm.jsx
@@ -1,16 +1,14 @@
 import React, { useState } from "react";
 import { useUser } from "@clerk/clerk-react";
 import { useNavigate } from "react-router-dom";
-import { useAppContext } from '../context/AppContext'; // 👈 import it
+import { useAppContext } from "../context/AppContext";
 
 const PostProjectForm = () => {
-
   const { user } = useUser();
   const navigate = useNavigate();
   const { profileData, loading: profileLoading } = useAppContext();
 
   const [loading, setLoading] = useState(false);
-
   const [formData, setFormData] = useState({
     title: "",
     description: "",
@@ -34,49 +32,42 @@ const PostProjectForm = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
-    if (profileLoading || !profileData?.id) {
+
+    if (profileLoading || !profileData?.clerkId) {
       alert("User profile is still loading. Please wait a moment.");
       setLoading(false);
-
       return;
     }
 
-
-    console.log("🧪 User ID:", profileData.id);
     const payload = {
       title: formData.title,
       description: formData.description,
-      tags: formData.tags ? formData.tags.split(',').map(t => t.trim()) : [],
-      techStack: formData.techStack ? formData.techStack.split(',').map(t => t.trim()) : [],
+      tags: formData.tags ? formData.tags.split(",").map((t) => t.trim()) : [],
+      techStack: formData.techStack
+        ? formData.techStack.split(",").map((t) => t.trim())
+        : [],
       maxTeamSize: parseInt(formData.maxTeamSize) || 1,
-      status: formData.status || 'Open',
-      creatorId: profileData?.clerkId,
+      status: formData.status || "Open",
+      difficulty: formData.difficulty || "",
+      visibility:
+        formData.collaborationType === "Open to all"
+          ? "Open to All"
+          : "Invite Only",
+      creatorId: profileData.clerkId,
     };
 
-
-    console.log("🚀 Payload ready to send:", payload);
-
-
-    console.log("👀 profileData.id (Clerk ID):", profileData?.id);
-    console.log("📤 Final payload being sent:", payload);
-
-
     try {
-      const res = await fetch('/api/projects', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+      const res = await fetch("/api/projects", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       });
-      console.log("🔗 POSTing to: http://localhost:4000/api/projects");
 
-      if (!res.ok) throw new Error('Failed to create project');
+      if (!res.ok) throw new Error("Failed to create project");
 
-      console.log('✅ Project created');
-      navigate('/my-projects');
+      navigate("/my-projects");
     } catch (err) {
-      console.error('❌ Error creating project:', err.message);
+      console.error("❌ Error creating project:", err.message);
     } finally {
       setLoading(false);
     }
@@ -87,6 +78,7 @@ const PostProjectForm = () => {
 
   const sectionClass =
     "space-y-6 bg-gray-950 p-6 rounded-xl border border-gray-800";
+
   return (
     <div className="min-h-screen px-6 py-12 bg-black text-white">
       <div className="max-w-5xl mx-auto space-y-10">
@@ -101,7 +93,6 @@ const PostProjectForm = () => {
           {/* Basic Info */}
           <div className={sectionClass}>
             <h2 className="text-2xl font-semibold mb-4">Basic Information</h2>
-
             <div>
               <label className="block mb-1">Project Title</label>
               <input
@@ -129,7 +120,9 @@ const PostProjectForm = () => {
 
           {/* Collaboration */}
           <div className={sectionClass}>
-            <h2 className="text-2xl font-semibold mb-4">Collaboration Details</h2>
+            <h2 className="text-2xl font-semibold mb-4">
+              Collaboration Details
+            </h2>
 
             <div>
               <label className="block mb-1">Project Status</label>
@@ -163,7 +156,9 @@ const PostProjectForm = () => {
 
           {/* Tech Requirements */}
           <div className={sectionClass}>
-            <h2 className="text-2xl font-semibold mb-4">Technical Requirements</h2>
+            <h2 className="text-2xl font-semibold mb-4">
+              Technical Requirements
+            </h2>
 
             <div>
               <label className="block mb-1">Tech Stack Needed</label>

--- a/frontend/src/pages/ExploreProjects.jsx
+++ b/frontend/src/pages/ExploreProjects.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import dummyProjects from "../data/dummyProjects";
 import {
   MapPin,
   Sparkles,
@@ -9,127 +8,183 @@ import {
   ExternalLink,
   TrendingUp,
 } from "lucide-react";
+import { useUser } from "@clerk/clerk-react";
+import { useAppContext } from "../context/AppContext";
 
 export default function ExploreProjects() {
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState([]);
+  const [filters, setFilters] = useState({
+    tech: "",
+    tags: "",
+    difficulty: "",
+  });
+
+  const { profileData } = useAppContext();
+
+  const fetchProjects = async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (filters.tech) params.append("tech", filters.tech);
+      if (filters.tags) params.append("tags", filters.tags);
+      if (filters.difficulty) params.append("difficulty", filters.difficulty);
+
+      const res = await fetch(`/api/projects?${params.toString()}`);
+      const data = await res.json();
+      setProjects(data);
+    } catch (err) {
+      console.error("❌ Error fetching projects:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    setTimeout(() => {
-      const openProjects = dummyProjects.filter(
-        (proj) => proj.status === "Open for Collaboration"
-      );
-      setProjects(openProjects);
-      setLoading(false);
-    }, 1000); // Simulate loading
-  }, []);
+    fetchProjects();
+  }, [filters]);
 
-  if (loading)
-    return (
-      <div className="text-center text-slate-300 py-20 text-xl">
-        Loading projects...
-      </div>
-    );
+  const handleInterest = async (projectId) => {
+    if (!profileData?.id) {
+      alert("Please complete your profile first.");
+      return;
+    }
 
-  if (projects.length === 0)
-    return (
-      <div className="text-center text-slate-400 py-20 text-lg">
-        No open projects available.
-      </div>
-    );
+    try {
+      const res = await fetch(`/api/projects/${projectId}/interest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: profileData.id }),
+      });
+
+      if (!res.ok) throw new Error("Interest failed");
+      alert("✅ Interest recorded!");
+    } catch (err) {
+      console.error("❌ Error showing interest:", err.message);
+    }
+  };
+
+  const inputClass =
+    "bg-slate-800 border border-slate-600 text-white px-3 py-2 rounded-lg w-full";
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-white relative overflow-hidden px-6 py-12">
-      {/* Background Elements */}
-      <div className="absolute inset-0 overflow-hidden -z-10">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-600/10 rounded-full blur-3xl animate-pulse"></div>
-        <div className="absolute -bottom-40 -left-40 w-80 h-80 bg-purple-600/10 rounded-full blur-3xl animate-pulse delay-1000"></div>
-        <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-emerald-600/5 rounded-full blur-3xl animate-pulse delay-2000"></div>
+    <div className="min-h-screen bg-black text-white px-6 py-12">
+      {/* Filters */}
+      <div className="max-w-5xl mx-auto mb-10 grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <input
+          className={inputClass}
+          placeholder="Tech Stack (e.g. React)"
+          value={filters.tech}
+          onChange={(e) => setFilters({ ...filters, tech: e.target.value })}
+        />
+        <input
+          className={inputClass}
+          placeholder="Tags (e.g. AI)"
+          value={filters.tags}
+          onChange={(e) => setFilters({ ...filters, tags: e.target.value })}
+        />
+        <select
+          className={inputClass}
+          value={filters.difficulty}
+          onChange={(e) =>
+            setFilters({ ...filters, difficulty: e.target.value })
+          }
+        >
+          <option value="">All Levels</option>
+          <option>Beginner</option>
+          <option>Intermediate</option>
+          <option>Advanced</option>
+        </select>
       </div>
 
-      {/* Page Header */}
-      <div className="text-center mb-20">
-        <div className="inline-flex items-center gap-3 bg-slate-800/50 backdrop-blur-sm px-6 py-3 rounded-full border border-slate-700/50 mb-8">
-          <TrendingUp className="w-5 h-5 text-emerald-400" />
-          <span className="text-emerald-300 font-semibold text-sm">Find Projects</span>
-        </div>
-        <h1 className="text-5xl lg:text-7xl font-black mb-6 leading-tight">
-          <span className="bg-gradient-to-r from-white via-blue-100 to-white bg-clip-text text-transparent">Explore</span>{" "}
-          <span className="bg-gradient-to-r from-blue-400 via-purple-400 to-emerald-400 bg-clip-text text-transparent">Projects</span>
-        </h1>
-        <p className="text-slate-400 text-lg max-w-3xl mx-auto leading-relaxed">
-          Browse open-source and collaborative project ideas from developers worldwide. Discover something you want to contribute to!
+      {/* Header */}
+      <div className="text-center mb-12">
+        <h1 className="text-5xl font-black">Explore Projects</h1>
+        <p className="text-slate-400 mt-2">
+          Join real ideas, contribute, and collaborate
         </p>
       </div>
 
-      {/* Projects Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-        {projects.map((proj) => (
-          <div
-            key={proj.id}
-            className="group relative bg-gradient-to-br from-slate-900/90 to-slate-800/90 backdrop-blur-sm border border-slate-700/50 rounded-2xl p-7 hover:border-slate-500/50 transition-all duration-500 hover:shadow-2xl hover:shadow-slate-900/20 hover:-translate-y-1"
-          >
-            <div className="relative z-10">
-              <div className="flex justify-between items-center mb-4">
-                <h2 className="text-white text-xl font-bold truncate group-hover:text-blue-200 transition-colors duration-300">
-                  {proj.title}
-                </h2>
-                <span className="text-sm text-blue-400 border border-blue-700/50 px-2 py-0.5 rounded-full bg-blue-900/40">
-                  {proj.status}
-                </span>
-              </div>
-              <p className="text-slate-300 text-sm mb-4 leading-relaxed line-clamp-3">
-                {proj.description}
-              </p>
-              <div className="mb-4">
-                <h4 className="text-white text-sm font-bold mb-2 flex items-center gap-2">
-                  <Sparkles className="w-4 h-4 text-purple-300" /> Tech Stack
-                </h4>
-                <div className="flex flex-wrap gap-2">
-                  {proj.techStack.map((tech, i) => (
-                    <span
-                      key={i}
-                      className="px-3 py-1.5 bg-slate-800/80 border border-slate-600/50 text-slate-200 text-xs font-medium rounded-full hover:border-slate-500/50 hover:bg-slate-700/80 transition-all duration-300"
-                    >
-                      {tech}
-                    </span>
-                  ))}
+      {loading ? (
+        <div className="text-center text-slate-300 text-lg">
+          Loading projects...
+        </div>
+      ) : projects.length === 0 ? (
+        <div className="text-center text-slate-400 text-md">
+          No projects found.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
+          {projects.map((proj) => (
+            <div
+              key={proj.id}
+              className="group relative bg-gradient-to-br from-slate-900/90 to-slate-800/90 border border-slate-700/50 rounded-2xl p-7 hover:border-slate-500/50 transition-all duration-500 hover:shadow-2xl hover:shadow-slate-900/20 hover:-translate-y-1"
+            >
+              <div className="relative z-10">
+                <div className="flex justify-between items-center mb-4">
+                  <h2 className="text-white text-xl font-bold truncate group-hover:text-blue-200 transition-colors duration-300">
+                    {proj.title}
+                  </h2>
+                  <span className="text-sm text-blue-400 border border-blue-700/50 px-2 py-0.5 rounded-full bg-blue-900/40">
+                    {proj.status}
+                  </span>
                 </div>
-              </div>
-              <div className="mb-4">
-                <h4 className="text-white text-sm font-bold mb-2 flex items-center gap-2">
-                  <Users className="w-4 h-4 text-emerald-300" /> Roles Needed
-                </h4>
-                <div className="flex flex-wrap gap-2">
-                  {proj.rolesNeeded.map((role, i) => (
-                    <span
-                      key={i}
-                      className="px-3 py-1.5 bg-slate-800/80 border border-slate-600/50 text-slate-300 text-xs font-medium rounded-full hover:border-slate-500/50 hover:bg-slate-700/80 transition-all duration-300"
-                    >
-                      {role}
-                    </span>
-                  ))}
+                <p className="text-slate-300 text-sm mb-4 leading-relaxed line-clamp-3">
+                  {proj.description}
+                </p>
+
+                <div className="mb-4">
+                  <h4 className="text-white text-sm font-bold mb-2 flex items-center gap-2">
+                    <Sparkles className="w-4 h-4 text-purple-300" /> Tech Stack
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {proj.techStack?.map((tech, i) => (
+                      <span
+                        key={i}
+                        className="px-3 py-1.5 bg-slate-800/80 border border-slate-600/50 text-slate-200 text-xs font-medium rounded-full"
+                      >
+                        {tech}
+                      </span>
+                    ))}
+                  </div>
                 </div>
-              </div>
-              <div className="flex gap-3">
-                <button
-                  onClick={() => console.log(`Interest shown in: ${proj.title}`)}
-                  className="flex-1 flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600 text-white rounded-xl transition-all duration-300 text-sm font-semibold shadow-lg hover:shadow-blue-500/25 hover:-translate-y-0.5 group/btn"
-                >
-                  <Send className="w-4 h-4 group-hover/btn:translate-x-0.5 transition-transform duration-300" />
-                  Show Interest
-                </button>
-                <button className="p-3 bg-slate-800/80 border border-slate-600/50 rounded-xl hover:border-slate-500/50 hover:bg-slate-700/80 transition-all duration-300">
-                  <Github className="w-4 h-4 text-slate-300 hover:text-white" />
-                </button>
-                <button className="p-3 bg-slate-800/80 border border-slate-600/50 rounded-xl hover:border-slate-500/50 hover:bg-slate-700/80 transition-all duration-300">
-                  <ExternalLink className="w-4 h-4 text-slate-300 hover:text-white" />
-                </button>
+
+                <div className="mb-4">
+                  <h4 className="text-white text-sm font-bold mb-2 flex items-center gap-2">
+                    <Users className="w-4 h-4 text-emerald-300" /> Roles Needed
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {proj.rolesNeeded?.map((role, i) => (
+                      <span
+                        key={i}
+                        className="px-3 py-1.5 bg-slate-800/80 border border-slate-600/50 text-slate-300 text-xs font-medium rounded-full"
+                      >
+                        {role}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="flex gap-3">
+                  <button
+                    onClick={() => handleInterest(proj.id)}
+                    className="flex-1 flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl text-sm font-semibold shadow-lg"
+                  >
+                    <Send className="w-4 h-4" />
+                    Show Interest
+                  </button>
+                  <button className="p-3 bg-slate-800/80 border border-slate-600/50 rounded-xl">
+                    <Github className="w-4 h-4 text-slate-300" />
+                  </button>
+                  <button className="p-3 bg-slate-800/80 border border-slate-600/50 rounded-xl">
+                    <ExternalLink className="w-4 h-4 text-slate-300" />
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/MyProjectsPage.jsx
+++ b/frontend/src/pages/MyProjectsPage.jsx
@@ -1,104 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Edit, Eye, Users, X } from "lucide-react";
-
-const projects = [
-  {
-    id: 1,
-    name: "Hackathon Helper",
-    description: "A tool to help teams organize for hackathons.",
-    status: "In Progress",
-    inviteStatus: "Pending",
-    collaborationType: "Open to all",
-    techStack: "React, Node.js",
-    customTech: "Figma",
-    difficulty: "Intermediate",
-    roles: "Frontend Developer, Designer",
-    customRoles: "UI/UX Specialist",
-    maxTeamSize: 5,
-    deadline: "2024-08-01",
-    tags: "Hackathon, Organizer, WebApp",
-  },
-  {
-    id: 2,
-    name: "Project Collab",
-    description: "A platform for students to find project partners.",
-    status: "Completed",
-    inviteStatus: "Accepted",
-    collaborationType: "Invite only",
-    techStack: "Next.js, Prisma",
-    customTech: "Socket.io",
-    difficulty: "Advanced",
-    roles: "Backend Developer, Fullstack",
-    customRoles: "DevOps",
-    maxTeamSize: 6,
-    deadline: "2024-07-15",
-    tags: "Collaboration, Platform, WebApp",
-  },
-  {
-    id: 3,
-    name: "Idea Board",
-    description: "A collaborative whiteboard for brainstorming and ideation.",
-    status: "In Progress",
-    inviteStatus: "Pending",
-    collaborationType: "Open to all",
-    techStack: "Vue, Firebase",
-    customTech: "Draw.io",
-    difficulty: "Beginner",
-    roles: "Frontend Developer, Tester",
-    customRoles: "Product Manager",
-    maxTeamSize: 4,
-    deadline: "2024-09-10",
-    tags: "Whiteboard, Brainstorm, Teamwork",
-  },
-  {
-    id: 4,
-    name: "DevConnect",
-    description: "A networking app for developers to connect and share portfolios.",
-    status: "Completed",
-    inviteStatus: "Accepted",
-    collaborationType: "Invite only",
-    techStack: "React Native, Express",
-    customTech: "Expo",
-    difficulty: "Intermediate",
-    roles: "Mobile Developer, Designer",
-    customRoles: "Community Manager",
-    maxTeamSize: 8,
-    deadline: "2024-10-05",
-    tags: "Networking, Mobile, Portfolio",
-  },
-  {
-    id: 5,
-    name: "Bug Tracker",
-    description: "A simple bug tracking tool for small teams and hackathons.",
-    status: "In Progress",
-    inviteStatus: "Pending",
-    collaborationType: "Open to all",
-    techStack: "Django, React",
-    customTech: "Sentry",
-    difficulty: "Intermediate",
-    roles: "Backend Developer, QA",
-    customRoles: "Scrum Master",
-    maxTeamSize: 7,
-    deadline: "2024-08-20",
-    tags: "Bug, Tracker, QA",
-  },
-  {
-    id: 6,
-    name: "Open Source Hub",
-    description: "A hub for discovering and contributing to open source projects.",
-    status: "Completed",
-    inviteStatus: "Accepted",
-    collaborationType: "Open to all",
-    techStack: "Ruby on Rails, React",
-    customTech: "GitHub API",
-    difficulty: "Advanced",
-    roles: "Fullstack Developer, Maintainer",
-    customRoles: "Community Lead",
-    maxTeamSize: 10,
-    deadline: "2024-12-01",
-    tags: "Open Source, Community, Contribution",
-  },
-];
+import { useUser } from "@clerk/clerk-react";
+import { useAppContext } from "../context/AppContext";
 
 const borderColors = [
   "hover:border-purple-500/30",
@@ -112,27 +15,72 @@ const borderColors = [
 const inviteStatusColors = {
   Accepted: "bg-green-700/30 text-green-400",
   Pending: "bg-yellow-700/30 text-yellow-400",
+  Declined: "bg-red-700/30 text-red-400",
+  Expired: "bg-gray-600/30 text-gray-300",
 };
 
 export default function MyProjectsPage() {
+  const { user } = useUser();
+  const { profileData } = useAppContext();
+  const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+
   const [viewProject, setViewProject] = useState(null);
   const [editProject, setEditProject] = useState(null);
   const [editInviteStatus, setEditInviteStatus] = useState("");
 
+  useEffect(() => {
+    if (!profileData?.clerkId) return;
+
+    const fetchProjects = async () => {
+      try {
+        const res = await fetch(`/api/projects/mine`);
+        const data = await res.json();
+        setProjects(data || []);
+      } catch (err) {
+        console.error("Error fetching projects:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProjects();
+  }, [profileData]);
+
   const handleView = (project) => setViewProject(project);
+
   const handleEdit = (project) => {
     setEditProject(project);
-    setEditInviteStatus(project.inviteStatus);
+    setEditInviteStatus(project.inviteStatus || "Pending");
   };
+
   const closeModal = () => {
     setViewProject(null);
     setEditProject(null);
   };
+
   const handleInviteStatusChange = (e) => setEditInviteStatus(e.target.value);
-  const handleSave = () => {
-    // In real app, update backend here
-    if (editProject) editProject.inviteStatus = editInviteStatus;
-    closeModal();
+
+  const handleSave = async () => {
+    try {
+      const res = await fetch(`/api/projects/${editProject.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ inviteStatus: editInviteStatus }),
+      });
+
+      if (!res.ok) throw new Error("Update failed");
+
+      setProjects((prev) =>
+        prev.map((p) =>
+          p.id === editProject.id ? { ...p, inviteStatus: editInviteStatus } : p
+        )
+      );
+    } catch (err) {
+      console.error("Failed to update invite status:", err.message);
+    } finally {
+      closeModal();
+    }
   };
 
   return (
@@ -140,82 +88,137 @@ export default function MyProjectsPage() {
       {/* Heading */}
       <div className="text-center pt-20 pb-10">
         <h1 className="text-6xl md:text-7xl font-bold mb-4 leading-tight">
-          My <span className="bg-gradient-to-r from-blue-400 via-purple-500 to-blue-600 bg-clip-text text-transparent">Projects</span>
+          My{" "}
+          <span className="bg-gradient-to-r from-blue-400 via-purple-500 to-blue-600 bg-clip-text text-transparent">
+            Projects
+          </span>
         </h1>
         <p className="text-xl text-gray-400 max-w-2xl mx-auto leading-relaxed">
-          View and manage your hackathon and collaboration projects. Track status, invites, and more.
+          View and manage your hackathon and collaboration projects. Track
+          status, invites, and more.
         </p>
       </div>
 
       {/* Project Cards */}
-      <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8">
-        {projects.map((project, idx) => (
-          <div
-            key={project.id}
-            className={`bg-gradient-to-b from-gray-900/50 to-gray-900/20 border border-gray-700 rounded-2xl p-8 shadow-lg transition-all group relative overflow-hidden ${borderColors[idx % borderColors.length]}`}
-          >
-            {/* Project Title */}
-            <div className="flex items-center gap-3 mb-2">
-              <Users className="text-blue-400" size={28} />
-              <h2 className="text-3xl font-bold group-hover:text-blue-400 transition-colors">
-                {project.name}
-              </h2>
-            </div>
-            {/* Description */}
-            <p className="text-gray-300 text-lg mb-6">{project.description}</p>
-            {/* Status & Invite */}
-            <div className="flex flex-wrap gap-6 items-center mb-6">
-              <div>
-                <span className="text-gray-400 text-sm">Status:</span>
-                <span className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${project.status === "Completed" ? "bg-green-700/30 text-green-400" : "bg-blue-700/30 text-blue-400"}`}>
-                  {project.status}
-                </span>
+      {loading ? (
+        <div className="text-center text-gray-400 text-xl">
+          Loading projects...
+        </div>
+      ) : projects.length === 0 ? (
+        <div className="text-center text-gray-400 text-xl">
+          No projects posted yet.
+        </div>
+      ) : (
+        <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8">
+          {projects.map((project, idx) => (
+            <div
+              key={project.id}
+              className={`bg-gradient-to-b from-gray-900/50 to-gray-900/20 border border-gray-700 rounded-2xl p-8 shadow-lg transition-all group relative overflow-hidden ${
+                borderColors[idx % borderColors.length]
+              }`}
+            >
+              {/* Project Title */}
+              <div className="flex items-center gap-3 mb-2">
+                <Users className="text-blue-400" size={28} />
+                <h2 className="text-3xl font-bold group-hover:text-blue-400 transition-colors">
+                  {project.title}
+                </h2>
               </div>
-              <div>
-                <span className="text-gray-400 text-sm">Invite Status:</span>
-                <span className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${inviteStatusColors[project.inviteStatus] || "bg-gray-700/30 text-gray-300"}`}>
-                  {project.inviteStatus}
-                </span>
+              {/* Description */}
+              <p className="text-gray-300 text-lg mb-6">
+                {project.description}
+              </p>
+              {/* Status & Invite */}
+              <div className="flex flex-wrap gap-6 items-center mb-6">
+                <div>
+                  <span className="text-gray-400 text-sm">Status:</span>
+                  <span
+                    className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${
+                      project.status === "Completed"
+                        ? "bg-green-700/30 text-green-400"
+                        : "bg-blue-700/30 text-blue-400"
+                    }`}
+                  >
+                    {project.status}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-gray-400 text-sm">Invite Status:</span>
+                  <span
+                    className={`ml-2 px-3 py-1 rounded-full text-sm font-semibold ${
+                      inviteStatusColors[project.inviteStatus] ||
+                      "bg-gray-700/30 text-gray-300"
+                    }`}
+                  >
+                    {project.inviteStatus || "Pending"}
+                  </span>
+                </div>
               </div>
+              {/* Buttons */}
+              <div className="flex gap-4 mt-4">
+                <button
+                  onClick={() => handleView(project)}
+                  className="flex items-center gap-2 px-6 py-2 rounded-xl bg-white text-black font-semibold hover:bg-gray-100 transition-colors text-lg shadow"
+                >
+                  <Eye size={20} /> View
+                </button>
+                <button
+                  onClick={() => handleEdit(project)}
+                  className="flex items-center gap-2 px-6 py-2 rounded-xl border border-gray-600 text-white font-semibold hover:border-blue-500 hover:text-blue-400 transition-colors text-lg"
+                >
+                  <Edit size={20} /> Edit
+                </button>
+              </div>
+              <div className="absolute inset-0 pointer-events-none rounded-2xl group-hover:ring-2 group-hover:ring-blue-500/40 transition-all"></div>
             </div>
-            {/* Buttons */}
-            <div className="flex gap-4 mt-4">
-              <button onClick={() => handleView(project)} className="flex items-center gap-2 px-6 py-2 rounded-xl bg-white text-black font-semibold hover:bg-gray-100 transition-colors text-lg shadow">
-                <Eye size={20} /> View
-              </button>
-              <button onClick={() => handleEdit(project)} className="flex items-center gap-2 px-6 py-2 rounded-xl border border-gray-600 text-white font-semibold hover:border-blue-500 hover:text-blue-400 transition-colors text-lg">
-                <Edit size={20} /> Edit
-              </button>
-            </div>
-            {/* Card Hover Effect */}
-            <div className="absolute inset-0 pointer-events-none rounded-2xl group-hover:ring-2 group-hover:ring-blue-500/40 transition-all"></div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
 
       {/* View Modal */}
       {viewProject && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
           <div className="bg-gradient-to-b from-gray-900/90 to-gray-900/70 border border-gray-700 rounded-2xl p-10 max-w-2xl w-full shadow-2xl relative animate-fade-in">
-            <button onClick={closeModal} className="absolute top-4 right-4 text-gray-400 hover:text-red-400 transition-colors">
+            <button
+              onClick={closeModal}
+              className="absolute top-4 right-4 text-gray-400 hover:text-red-400 transition-colors"
+            >
               <X size={28} />
             </button>
             <h2 className="text-4xl font-bold mb-4 bg-gradient-to-r from-blue-400 via-purple-500 to-blue-600 bg-clip-text text-transparent">
-              {viewProject.name}
+              {viewProject.title}
             </h2>
             <div className="space-y-3 text-lg">
-              <div><span className="font-semibold text-gray-400">Description:</span> {viewProject.description}</div>
-              <div><span className="font-semibold text-gray-400">Status:</span> {viewProject.status}</div>
-              <div><span className="font-semibold text-gray-400">Invite Status:</span> {viewProject.inviteStatus}</div>
-              <div><span className="font-semibold text-gray-400">Collaboration Type:</span> {viewProject.collaborationType}</div>
-              <div><span className="font-semibold text-gray-400">Tech Stack:</span> {viewProject.techStack}</div>
-              <div><span className="font-semibold text-gray-400">Custom Tech:</span> {viewProject.customTech}</div>
-              <div><span className="font-semibold text-gray-400">Difficulty:</span> {viewProject.difficulty}</div>
-              <div><span className="font-semibold text-gray-400">Roles Open:</span> {viewProject.roles}</div>
-              <div><span className="font-semibold text-gray-400">Custom Roles:</span> {viewProject.customRoles}</div>
-              <div><span className="font-semibold text-gray-400">Max Team Size:</span> {viewProject.maxTeamSize}</div>
-              <div><span className="font-semibold text-gray-400">Deadline:</span> {viewProject.deadline}</div>
-              <div><span className="font-semibold text-gray-400">Tags:</span> {viewProject.tags}</div>
+              <div>
+                <span className="font-semibold text-gray-400">
+                  Description:
+                </span>{" "}
+                {viewProject.description}
+              </div>
+              <div>
+                <span className="font-semibold text-gray-400">Status:</span>{" "}
+                {viewProject.status}
+              </div>
+              <div>
+                <span className="font-semibold text-gray-400">
+                  Invite Status:
+                </span>{" "}
+                {viewProject.inviteStatus || "Pending"}
+              </div>
+              <div>
+                <span className="font-semibold text-gray-400">Tech Stack:</span>{" "}
+                {(viewProject.techStack || []).join(", ")}
+              </div>
+              <div>
+                <span className="font-semibold text-gray-400">Tags:</span>{" "}
+                {(viewProject.tags || []).join(", ")}
+              </div>
+              <div>
+                <span className="font-semibold text-gray-400">
+                  Max Team Size:
+                </span>{" "}
+                {viewProject.maxTeamSize}
+              </div>
             </div>
           </div>
         </div>
@@ -225,14 +228,19 @@ export default function MyProjectsPage() {
       {editProject && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
           <div className="bg-gradient-to-b from-gray-900/90 to-gray-900/70 border border-gray-700 rounded-2xl p-10 max-w-xl w-full shadow-2xl relative animate-fade-in">
-            <button onClick={closeModal} className="absolute top-4 right-4 text-gray-400 hover:text-red-400 transition-colors">
+            <button
+              onClick={closeModal}
+              className="absolute top-4 right-4 text-gray-400 hover:text-red-400 transition-colors"
+            >
               <X size={28} />
             </button>
             <h2 className="text-4xl font-bold mb-6 bg-gradient-to-r from-blue-400 via-purple-500 to-blue-600 bg-clip-text text-transparent">
               Edit Invite Status
             </h2>
             <div className="mb-8">
-              <label className="block mb-2 text-lg font-semibold text-gray-400">Invite Status</label>
+              <label className="block mb-2 text-lg font-semibold text-gray-400">
+                Invite Status
+              </label>
               <select
                 value={editInviteStatus}
                 onChange={handleInviteStatusChange}
@@ -255,4 +263,4 @@ export default function MyProjectsPage() {
       )}
     </div>
   );
-} 
+}


### PR DESCRIPTION
###  Post Project Flow + Explore Integration

#### User Flow
- Users can post new projects with metadata (tech stack, tags, difficulty, visibility)
- Projects marked as:
  - **Open to All** → appear in `/explore-projects`
  - **Invite Only** → visible only in "My Projects" for creator

####  Explore Features
- “Show Interest” button added to public projects
- Clicking "Show Interest" updates backend with user's intent

####  Filters Implemented
- Tech Stack
- Tags
- Difficulty Level
- Filters work dynamically on the `/explore-projects` page

####  Full Flow Covered
- Project Creation → Backend Save via `/api/projects`
- Public Projects → Shown on Explore Page
- Interest Click → Saved via `/api/interests`
- All integrated end-to-end and fully working


